### PR TITLE
Enable the I2C contructor to optionally accept a Wire object

### DIFF
--- a/Tic.cpp
+++ b/Tic.cpp
@@ -178,46 +178,44 @@ void TicSerial::sendCommandHeader(TicCommand cmd)
 
 void TicI2C::commandQuick(TicCommand cmd)
 {
-  Wire.beginTransmission(_address);
-  Wire.write((uint8_t)cmd);
-  _lastError = Wire.endTransmission();
+  _wire.beginTransmission(_address);
+  _wire.write((uint8_t)cmd);
+  _lastError = _wire.endTransmission();
 }
 
 void TicI2C::commandW32(TicCommand cmd, uint32_t val)
 {
-  Wire.beginTransmission(_address);
-  Wire.write((uint8_t)cmd);
-  Wire.write((uint8_t)(val >> 0)); // lowest byte
-  Wire.write((uint8_t)(val >> 8));
-  Wire.write((uint8_t)(val >> 16));
-  Wire.write((uint8_t)(val >> 24)); // highest byte
-  _lastError = Wire.endTransmission();
+  _wire.beginTransmission(_address);
+  _wire.write((uint8_t)cmd);
+  _wire.write((uint8_t)(val >> 0));
+  _wire.write((uint8_t)(val >> 8));
+  _wire.write((uint8_t)(val >> 16));
+  _wire.write((uint8_t)(val >> 24));
+  _lastError = _wire.endTransmission();
 }
 
 void TicI2C::commandW7(TicCommand cmd, uint8_t val)
 {
-  Wire.beginTransmission(_address);
-  Wire.write((uint8_t)cmd);
-  Wire.write((uint8_t)(val & 0x7F));
-  _lastError = Wire.endTransmission();
+  _wire.beginTransmission(_address);
+  _wire.write((uint8_t)cmd);
+  _wire.write((uint8_t)(val & 0x7F));
+  _lastError = _wire.endTransmission();
 }
 
 void TicI2C::getSegment(TicCommand cmd, uint8_t offset,
   uint8_t length, void * buffer)
 {
-  Wire.beginTransmission(_address);
-  Wire.write((uint8_t)cmd);
-  Wire.write(offset);
-  _lastError = Wire.endTransmission(false); // no stop (repeated start)
+  _wire.beginTransmission(_address);
+  _wire.write((uint8_t)cmd);
+  _wire.write(offset);
+  _lastError = _wire.endTransmission(false);
   if (_lastError)
   {
-    // Set the buffer bytes to 0 so the program will not use an uninitialized
-    // variable.
     memset(buffer, 0, length);
     return;
   }
 
-  uint8_t byteCount = Wire.requestFrom(_address, (uint8_t)length);
+  uint8_t byteCount = _wire.requestFrom(_address, (uint8_t)length);
   if (byteCount != length)
   {
     _lastError = 50;
@@ -229,7 +227,7 @@ void TicI2C::getSegment(TicCommand cmd, uint8_t offset,
   uint8_t * ptr = (uint8_t *)buffer;
   for (uint8_t i = 0; i < length; i++)
   {
-    *ptr = Wire.read();
+    *ptr = _wire.read();
     ptr++;
   }
 }

--- a/Tic.h
+++ b/Tic.h
@@ -1425,9 +1425,9 @@ public:
   ///
   /// The `address` parameter specifies the 7-bit I2C address to use, and it
   /// must match the Tic's "Device number" setting.  It defaults to 14.
-  TicI2C(uint8_t address = 14) : _address(address)
-  {
-  }
+// In Tic.h
+TicI2C(uint8_t address = 14, TwoWire& wire_interface = Wire) 
+    : _wire(wire_interface), _address(address) {};
 
   // TODO: support Wire1 on Arduino Due, and bit-banging I2C on any board?
 
@@ -1436,6 +1436,7 @@ public:
 
 private:
   const uint8_t _address;
+  TwoWire& _wire;
 
   void commandQuick(TicCommand cmd);
   void commandW32(TicCommand cmd, uint32_t val);


### PR DESCRIPTION
I have a board with multiple I2C busses and I needed to be able to control which one was being used. This appears to be working very nicely on my ESP32-based board.